### PR TITLE
[fix] Could not parse version constraint invalid version string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "magento 2 extension free"
   ],
   "require": {
-    "magento/framework": ">=103.0.*"
+    "magento/framework": "^103.0"
   },
   "type": "magento2-module",
   "license": [

--- a/src/Console/RemoveDuplicate.php
+++ b/src/Console/RemoveDuplicate.php
@@ -173,7 +173,7 @@ class RemoveDuplicate extends Command
             $filePaths = [];
 
             if (empty($gallery)) {
-                return Cli::RETURN_SUCCESS;
+                continue;
             }
 
             foreach ($gallery as $key => $galleryImage) {


### PR DESCRIPTION
- Fix Could not parse version constraint >=103.0.*: Invalid version string "103.0.*"
- The error encountered is due to the use of an invalid version string in your composer.json file. The * wildcard is not allowed in combination with other version constraints such as >=. 
- Minor bug fix for empty gallery inside the loop